### PR TITLE
Allow `--yes` arg to skip confirmation of uninstall

### DIFF
--- a/assets/uninstall.sh
+++ b/assets/uninstall.sh
@@ -3,10 +3,16 @@ if [ ! -r "/usr/local/git" ]; then
   echo "Git doesn't appear to be installed via this installer.  Aborting"
   exit 1
 fi
-echo "This will uninstall git by removing /usr/local/git/, and symlinks"
-printf "Type 'yes' if you are sure you wish to continue: "
-read response
-if [ "$response" == "yes" ]; then
+
+if [ "$1" != "--yes" ]; then
+  echo "This will uninstall git by removing /usr/local/git/, and symlinks"
+  printf "Type 'yes' if you are sure you wish to continue: "
+  read response
+else
+  response="yes"
+fi
+
+if [ "$response" != "yes" ]; then
   # remove all of the symlinks we've created
   pkgutil --files com.git.pkg | grep bin | while read f; do
     if [ -L /usr/local/$f ]; then


### PR DESCRIPTION
So we can more easily call this script from automation and other tools, add an argument `--yes` to skip the confirmation prompt for uninstall.