### PR TITLE
uninstall.sh: correctly interpret "yes"

### DIFF
--- a/assets/uninstall.sh
+++ b/assets/uninstall.sh
@@ -12,7 +12,7 @@ else
   response="yes"
 fi
 
-if [ "$response" != "yes" ]; then
+if [ "$response" == "yes" ]; then
   # remove all of the symlinks we've created
   pkgutil --files com.git.pkg | grep bin | while read f; do
     if [ -L /usr/local/$f ]; then


### PR DESCRIPTION
The uninstall script takes an optional "--yes" argument to avoid
interactively asking the user if it is OK to uninstall. However,
this causes problems when the user wants to upgrade because the
condition is actually the opposite!

This is a problem for "brew upgrade --cask git" because the first
uninstall fails due to needing sudo access, and the second one that
calls with sudo uses --yes.